### PR TITLE
Bump commons-fileupload from 1.4 to 1.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
 		<dependency>
 			<groupId>commons-fileupload</groupId>
 			<artifactId>commons-fileupload</artifactId>
-			<version>1.4</version>
+			<version>1.5</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-lang</groupId>


### PR DESCRIPTION
### Description

In this pull request, the version of the dependency `commons-fileupload` in the `pom.xml` file has been updated from `1.4` to `1.5`.

Summary of changes:
- Update the version of the `commons-fileupload` dependency in the `pom.xml` file from `1.4` to `1.5`.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Bump the version of `commons-fileupload` from 1.4 to 1.5 in the `pom.xml` file.

### Why are these changes being made?

This update addresses security vulnerabilities and bug fixes present in version 1.4, ensuring the application remains secure and stable. Upgrading to the latest version is a best practice to leverage improvements and maintain compatibility with other dependencies.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->